### PR TITLE
feat: add Wearable-style custom equalizer

### DIFF
--- a/app/src/main/java/com/benegedeniz/budsdynamiceq/bluetooth/BudsController.kt
+++ b/app/src/main/java/com/benegedeniz/budsdynamiceq/bluetooth/BudsController.kt
@@ -8,6 +8,7 @@ import android.bluetooth.BluetoothSocket
 import android.content.Context
 import android.util.Log
 import com.benegedeniz.budsdynamiceq.data.model.EqPreset
+import com.benegedeniz.budsdynamiceq.data.model.CustomEqualizer
 import com.benegedeniz.budsdynamiceq.data.model.EqRule
 import com.benegedeniz.budsdynamiceq.data.model.NoiseControlMode
 import com.benegedeniz.budsdynamiceq.data.model.FitTestResult
@@ -101,6 +102,7 @@ class BudsController(
     val stereoBalance = deviceState.stereoBalance.asStateFlow()
     val lastMatchedRule = deviceState.lastMatchedRule.asStateFlow()
     val manualPreset = deviceState.manualPreset.asStateFlow()
+    val customEqBands = deviceState.customEqBands.asStateFlow()
     val manualNoiseControl = deviceState.manualNoiseControl.asStateFlow()
     val activeNoiseControl = deviceState.activeNoiseControl.asStateFlow()
 
@@ -127,6 +129,7 @@ class BudsController(
         deviceState.savedDeviceMac.value = settingsRepo.getSavedMacAddress()
         deviceState.connectedModel.value = settingsRepo.getDetectedModel(deviceState.savedDeviceMac.value ?: "")
         deviceState.modelOverride.value = settingsRepo.getModelOverride(deviceState.savedDeviceMac.value ?: "")
+        loadCustomEqBands()
         
         scope.launch(Dispatchers.IO) {
             for (packet in _packetQueue) {
@@ -137,6 +140,9 @@ class BudsController(
                 try {
                     socket?.outputStream?.write(packet.data)
                     delay(250) // Hardware processing buffer time
+                    if (packet.isNc) {
+                        writeCustomEqFollowup()
+                    }
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to send queued packet: ${e.message}")
                 }
@@ -260,6 +266,7 @@ class BudsController(
     fun connect(device: BluetoothDevice) {
         settingsRepo.saveMacAddress(device.address)
         deviceState.savedDeviceMac.value = device.address
+        loadCustomEqBands()
         targetDevice = device
 
         var savedModel = settingsRepo.getDetectedModel(device.address)
@@ -394,6 +401,7 @@ class BudsController(
             deviceState.savedDeviceMac.value = null
             deviceState.connectedModel.value = BudsModel.UNKNOWN
             deviceState.modelOverride.value = null
+            loadCustomEqBands()
         }
         synchronized(spatialConsumers) { spatialConsumers.clear() }
         stopSpatialSensor()
@@ -417,15 +425,68 @@ class BudsController(
     }
 
     fun sendEqualizer(preset: EqPreset?) {
-        if (preset == lastSentEq && preset != null) return
+        if (preset == EqPreset.DEFAULT || preset == EqPreset.IGNORE) return
+
+        val isCustom = preset == EqPreset.CUSTOM
+        if (isCustom) {
+            sendCustomEqualizerBands()
+        }
+        if (!isCustom && preset == lastSentEq && preset != null) return
+        if (isCustom && lastSentEq == EqPreset.CUSTOM) return
+
         lastSentEq = preset
-        
+
         val payloadByte = preset?.payloadByte ?: 0x00.toByte()
         val payload = byteArrayOf(payloadByte)
 
         val packet = SppPacketEncoder.buildPacket(SppPacketEncoder.MSG_ID_EQUALIZER, payload)
         packetQueue.trySend(packet)
         Log.i(TAG, "Queued EQ preset: ${preset?.name ?: "OFF"} (byte: 0x%02X)".format(payloadByte))
+    }
+
+    fun setCustomEqBands(bands: List<Int>) {
+        val clamped = CustomEqualizer.clamp(bands)
+        if (clamped == deviceState.customEqBands.value) return
+        deviceState.customEqBands.value = clamped
+        settingsRepo.saveCustomEqBands(deviceState.savedDeviceMac.value, clamped)
+        if (lastSentEq == EqPreset.CUSTOM) {
+            sendCustomEqualizerBands()
+        }
+    }
+
+    private fun loadCustomEqBands() {
+        deviceState.customEqBands.value = settingsRepo.getCustomEqBands(deviceState.savedDeviceMac.value)
+    }
+
+    private fun sendCustomEqualizerBands() {
+        if (!effectiveModel.value.supportsCustomEqualizer) return
+        val payload = SppPacketEncoder.buildCustomEqualizerPayload(deviceState.customEqBands.value)
+        val packet = SppPacketEncoder.buildPacket(SppPacketEncoder.MSG_ID_CUSTOM_EQUALIZE_SEND, payload)
+        packetQueue.trySend(packet)
+        Log.i(TAG, "Queued custom EQ bands: ${deviceState.customEqBands.value}")
+    }
+
+    private suspend fun writeCustomEqFollowup() {
+        if (lastSentEq != EqPreset.CUSTOM) return
+        if (!effectiveModel.value.supportsCustomEqualizer) return
+        try {
+            val bandsPacket = SppPacketEncoder.buildPacket(
+                SppPacketEncoder.MSG_ID_CUSTOM_EQUALIZE_SEND,
+                SppPacketEncoder.buildCustomEqualizerPayload(deviceState.customEqBands.value)
+            )
+            socket?.outputStream?.write(bandsPacket)
+            socket?.outputStream?.flush()
+            delay(80)
+            val eqPacket = SppPacketEncoder.buildPacket(
+                SppPacketEncoder.MSG_ID_EQUALIZER,
+                byteArrayOf(EqPreset.CUSTOM.payloadByte)
+            )
+            socket?.outputStream?.write(eqPacket)
+            socket?.outputStream?.flush()
+            Log.i(TAG, "Re-pushed custom EQ after noise-control update")
+        } catch (e: Exception) {
+            Log.e(TAG, "Custom EQ follow-up failed: ${e.message}")
+        }
     }
 
     fun sendNoiseControl(mode: NoiseControlMode?) {
@@ -454,6 +515,7 @@ class BudsController(
                         socket?.outputStream?.write(packet)
                         socket?.outputStream?.flush()
                         Log.i(TAG, "Sent Noise Control directly without throttle: ${mode.name} (attempt 1)")
+                        writeCustomEqFollowup()
                     } else {
                         _packetQueue.trySend(QueuedPacket(packet, isNc = true, ncMode = mode))
                         Log.i(TAG, "Sent Noise Control to queue: ${mode.name} (attempt $attempt/5)")

--- a/app/src/main/java/com/benegedeniz/budsdynamiceq/bluetooth/BudsModel.kt
+++ b/app/src/main/java/com/benegedeniz/budsdynamiceq/bluetooth/BudsModel.kt
@@ -8,7 +8,8 @@ enum class BudsModel(
     val supportsFitTest: Boolean,
     val isExperimentalGestures: Boolean,
     val supportsFmgRingWhileWearing: Boolean,
-    val supportsDoubleTapEdge: Boolean
+    val supportsDoubleTapEdge: Boolean,
+    val supportsCustomEqualizer: Boolean
 ) {
     BUDS_2(
         displayNameRes = com.benegedeniz.budsdynamiceq.R.string.model_buds_2,
@@ -18,7 +19,8 @@ enum class BudsModel(
         supportsFitTest = true,
         isExperimentalGestures = true,
         supportsFmgRingWhileWearing = true,
-        supportsDoubleTapEdge = true
+        supportsDoubleTapEdge = true,
+        supportsCustomEqualizer = false
     ),
     BUDS_2_PRO(
         displayNameRes = com.benegedeniz.budsdynamiceq.R.string.model_buds_2_pro,
@@ -28,7 +30,8 @@ enum class BudsModel(
         supportsFitTest = true,
         isExperimentalGestures = true,
         supportsFmgRingWhileWearing = true,
-        supportsDoubleTapEdge = true
+        supportsDoubleTapEdge = true,
+        supportsCustomEqualizer = false
     ),
     BUDS_3(
         displayNameRes = com.benegedeniz.budsdynamiceq.R.string.model_buds_3,
@@ -38,7 +41,8 @@ enum class BudsModel(
         supportsFitTest = false,
         isExperimentalGestures = true,
         supportsFmgRingWhileWearing = false,
-        supportsDoubleTapEdge = false
+        supportsDoubleTapEdge = false,
+        supportsCustomEqualizer = true
     ),
     BUDS_3_PRO(
         displayNameRes = com.benegedeniz.budsdynamiceq.R.string.model_buds_3_pro,
@@ -48,7 +52,8 @@ enum class BudsModel(
         supportsFitTest = true,
         isExperimentalGestures = true,
         supportsFmgRingWhileWearing = false,
-        supportsDoubleTapEdge = false
+        supportsDoubleTapEdge = false,
+        supportsCustomEqualizer = true
     ),
     BUDS_4_PRO(
         displayNameRes = com.benegedeniz.budsdynamiceq.R.string.model_buds_4_pro,
@@ -58,7 +63,8 @@ enum class BudsModel(
         supportsFitTest = true,
         isExperimentalGestures = false,
         supportsFmgRingWhileWearing = false,
-        supportsDoubleTapEdge = false
+        supportsDoubleTapEdge = false,
+        supportsCustomEqualizer = true
     ),
     BUDS_4(
         displayNameRes = com.benegedeniz.budsdynamiceq.R.string.model_buds_4,
@@ -68,7 +74,8 @@ enum class BudsModel(
         supportsFitTest = false,
         isExperimentalGestures = false,
         supportsFmgRingWhileWearing = false,
-        supportsDoubleTapEdge = false
+        supportsDoubleTapEdge = false,
+        supportsCustomEqualizer = true
     ),
     UNKNOWN(
         displayNameRes = com.benegedeniz.budsdynamiceq.R.string.model_buds_unknown,
@@ -78,6 +85,7 @@ enum class BudsModel(
         supportsFitTest = true,
         isExperimentalGestures = true,
         supportsFmgRingWhileWearing = false,
-        supportsDoubleTapEdge = false
+        supportsDoubleTapEdge = false,
+        supportsCustomEqualizer = true
     )
 }

--- a/app/src/main/java/com/benegedeniz/budsdynamiceq/bluetooth/SppPacketEncoder.kt
+++ b/app/src/main/java/com/benegedeniz/budsdynamiceq/bluetooth/SppPacketEncoder.kt
@@ -5,6 +5,7 @@ object SppPacketEncoder {
     private const val SOM: Byte = 0xFD.toByte()
     private const val EOM: Byte = 0xDD.toByte()
     const val MSG_ID_EQUALIZER: Byte = 0x86.toByte()
+    const val MSG_ID_CUSTOM_EQUALIZE_SEND: Byte = 137.toByte() // 0x89; Buds 3/4 custom 9-band table
     const val MSG_ID_NOISE_CONTROLS: Byte = 0x78.toByte()
     const val MSG_ID_SET_CALL_PATH_CONTROL: Byte = 0x6E.toByte() // 110 (0x6E)
     const val MSG_ID_SET_ANC_WITH_ONE_EARBUD: Byte = 0x6F.toByte() // 111 (0x6F)
@@ -56,6 +57,16 @@ object SppPacketEncoder {
         packet[offset] = EOM
         
         return packet
+    }
+
+    fun buildCustomEqualizerPayload(gains: List<Int>): ByteArray {
+        val clamped = com.benegedeniz.budsdynamiceq.data.model.CustomEqualizer.clamp(gains)
+        val payload = ByteArray(1 + clamped.size)
+        payload[0] = clamped.size.toByte()
+        for (i in clamped.indices) {
+            payload[i + 1] = clamped[i].toByte()
+        }
+        return payload
     }
 
     /**

--- a/app/src/main/java/com/benegedeniz/budsdynamiceq/data/model/CustomEqualizer.kt
+++ b/app/src/main/java/com/benegedeniz/budsdynamiceq/data/model/CustomEqualizer.kt
@@ -1,0 +1,54 @@
+package com.benegedeniz.budsdynamiceq.data.model
+
+object CustomEqualizer {
+    const val BAND_COUNT = 9
+    const val GAIN_MIN = -10
+    const val GAIN_MAX = 10
+
+    val BAND_LABELS = listOf("63", "125", "250", "500", "1k", "2k", "4k", "8k", "16k")
+    val FLAT: List<Int> = List(BAND_COUNT) { 0 }
+
+    val WEARABLE_PRESETS = listOf(
+        EqPreset.NORMAL,
+        EqPreset.BASS_BOOST,
+        EqPreset.SOFT,
+        EqPreset.DYNAMIC,
+        EqPreset.CLEAR,
+        EqPreset.TREBLE_BOOST
+    )
+
+    fun clamp(bands: List<Int>): List<Int> {
+        if (bands.size != BAND_COUNT) return FLAT
+        return bands.map { it.coerceIn(GAIN_MIN, GAIN_MAX) }
+    }
+
+    fun parseStored(raw: String?): List<Int> {
+        if (raw.isNullOrBlank()) return FLAT
+        val parts = raw.split(',')
+        if (parts.size != BAND_COUNT) return FLAT
+        return try {
+            clamp(parts.map { it.trim().toInt() })
+        } catch (_: NumberFormatException) {
+            FLAT
+        }
+    }
+
+    fun serialize(bands: List<Int>): String = clamp(bands).joinToString(",")
+
+    fun previewBands(preset: EqPreset, custom: List<Int>): List<Int> {
+        return when (preset) {
+            EqPreset.CUSTOM -> clamp(custom)
+            EqPreset.BASS_BOOST -> listOf(6, 4, 2, 0, 0, 0, 0, 0, 0)
+            EqPreset.SOFT -> listOf(-2, 0, 2, 3, 2, 0, -1, -2, -3)
+            EqPreset.DYNAMIC -> listOf(4, 2, 0, -1, 0, 1, 3, 4, 3)
+            EqPreset.CLEAR -> listOf(-3, -1, 0, 1, 2, 3, 4, 3, 2)
+            EqPreset.TREBLE_BOOST -> listOf(0, 0, 0, 0, 1, 2, 4, 6, 6)
+            else -> FLAT
+        }
+    }
+
+    fun formatGain(gain: Int): String = when {
+        gain > 0 -> "+$gain"
+        else -> gain.toString()
+    }
+}

--- a/app/src/main/java/com/benegedeniz/budsdynamiceq/data/model/EqPreset.kt
+++ b/app/src/main/java/com/benegedeniz/budsdynamiceq/data/model/EqPreset.kt
@@ -11,5 +11,7 @@ enum class EqPreset(@param:StringRes val displayNameRes: Int, val payloadByte: B
     SOFT(R.string.eq_soft, 0x02),
     DYNAMIC(R.string.eq_dynamic, 0x03),
     CLEAR(R.string.eq_clear, 0x04),
-    TREBLE_BOOST(R.string.eq_treble_boost, 0x05);
+    TREBLE_BOOST(R.string.eq_treble_boost, 0x05),
+    // Wearable "Custom": EQUALIZER payload 0x07 (preset index 6, sent as index+1).
+    CUSTOM(R.string.eq_custom, 0x07);
 }

--- a/app/src/main/java/com/benegedeniz/budsdynamiceq/data/repository/DeviceStateRepository.kt
+++ b/app/src/main/java/com/benegedeniz/budsdynamiceq/data/repository/DeviceStateRepository.kt
@@ -63,6 +63,7 @@ class DeviceStateRepository {
     
     val lastMatchedRule = MutableStateFlow<EqRule?>(null)
     val manualPreset = MutableStateFlow<EqPreset?>(null)
+    val customEqBands = MutableStateFlow(com.benegedeniz.budsdynamiceq.data.model.CustomEqualizer.FLAT)
     val manualNoiseControl = MutableStateFlow<NoiseControlMode?>(null)
     val activeNoiseControl = MutableStateFlow<NoiseControlMode?>(null)
 

--- a/app/src/main/java/com/benegedeniz/budsdynamiceq/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/benegedeniz/budsdynamiceq/data/repository/SettingsRepository.kt
@@ -30,7 +30,24 @@ class SettingsRepository(context: Context) {
             .remove("detected_model_$mac")
             .remove("model_override_$mac")
             .remove("experimental_gestures_enabled_$mac")
+            .remove(customEqKey(mac))
             .apply()
+    }
+
+    fun getCustomEqBands(mac: String?): List<Int> {
+        val raw = prefs.getString(customEqKey(mac), null)
+            ?: mac?.let { prefs.getString(customEqKey(null), null) }
+        return com.benegedeniz.budsdynamiceq.data.model.CustomEqualizer.parseStored(raw)
+    }
+
+    fun saveCustomEqBands(mac: String?, bands: List<Int>) {
+        prefs.edit()
+            .putString(customEqKey(mac), com.benegedeniz.budsdynamiceq.data.model.CustomEqualizer.serialize(bands))
+            .apply()
+    }
+
+    private fun customEqKey(mac: String?): String {
+        return if (mac.isNullOrBlank()) "custom_eq_bands" else "custom_eq_bands_$mac"
     }
 
     fun getDetectedModel(mac: String): BudsModel {

--- a/app/src/main/java/com/benegedeniz/budsdynamiceq/ui/buds/BudsScreen.kt
+++ b/app/src/main/java/com/benegedeniz/budsdynamiceq/ui/buds/BudsScreen.kt
@@ -97,6 +97,7 @@ fun BudsScreen(
     onSoundBalanceTestClick: () -> Unit = {},
     onSettingsClick: () -> Unit = {},
     onFindMyBudsClick: () -> Unit = {},
+    onEqualizerClick: () -> Unit = {},
     onOpenSearch: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -700,6 +701,20 @@ fun BudsScreen(
                         }
                     }
                 }
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+
+            // Equalizer
+            item {
+                EqualizerCard(
+                    isConnected = isConnected,
+                    currentPreset = if (lastMatchedRule == null || lastMatchedRule.preset == EqPreset.DEFAULT) {
+                        manualPreset
+                    } else {
+                        lastMatchedRule.preset
+                    },
+                    onClick = onEqualizerClick
+                )
                 Spacer(modifier = Modifier.height(16.dp))
             }
 

--- a/app/src/main/java/com/benegedeniz/budsdynamiceq/ui/buds/components/AppSearchOverlay.kt
+++ b/app/src/main/java/com/benegedeniz/budsdynamiceq/ui/buds/components/AppSearchOverlay.kt
@@ -59,6 +59,7 @@ fun AppSearchOverlay(
     onWearStateClick: () -> Unit,
     onSoundBalanceTestClick: () -> Unit,
     onFindMyBudsClick: () -> Unit,
+    onEqualizerClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var searchQuery by remember { mutableStateOf("") }
@@ -179,6 +180,10 @@ fun AppSearchOverlay(
                     
                     val titleFindBuds = context.getString(R.string.find_my_earbuds).lowercase()
                     val mFindBuds = titleFindBuds.contains(query)
+
+                    val titleEqualizer = context.getString(R.string.equalizer).lowercase()
+                    val mEqualizer = titleEqualizer.contains(query) ||
+                        context.getString(R.string.eq_custom).lowercase().contains(query)
                     
                     val toggleDoubleTap = context.getString(R.string.double_tap_earbud_edge).lowercase()
                     val mDoubleTap = effectiveModel.supportsDoubleTapEdge && toggleDoubleTap.contains(query)
@@ -190,7 +195,7 @@ fun AppSearchOverlay(
                     val pauseMediaDesc = context.getString(R.string.pauses_media_when_ambient_mode_is_trigge).lowercase()
                     val mPauseMedia = effectiveModel.supportsConversationDetection && (togglePauseMedia.contains(query) || pauseMediaDesc.contains(query))
 
-                    if (mNoiseControls || mOneEarbud || mAmbientCall || mInEarCall || mFitTest || mWearState || mSoundBalance || mFindBuds || mDoubleTap || mVoiceDetect || mPauseMedia) {
+                    if (mNoiseControls || mOneEarbud || mAmbientCall || mInEarCall || mFitTest || mWearState || mSoundBalance || mFindBuds || mEqualizer || mDoubleTap || mVoiceDetect || mPauseMedia) {
                         item(key = "header_home") {
                             SearchSectionHeader(
                                 appName = context.getString(R.string.app_name),
@@ -301,6 +306,24 @@ fun AppSearchOverlay(
                                 onClick = { 
                                     onClose()
                                     onFindMyBudsClick() 
+                                },
+                                modifier = Modifier.animateItem().padding(horizontal = 16.dp, vertical = 8.dp)
+                            )
+                        }
+                    }
+
+                    if (mEqualizer) {
+                        item(key = "equalizer") {
+                            EqualizerCard(
+                                isConnected = budsState.isConnected,
+                                currentPreset = if (budsState.lastMatchedRule == null || budsState.lastMatchedRule?.preset == com.benegedeniz.budsdynamiceq.data.model.EqPreset.DEFAULT) {
+                                    budsState.manualPreset
+                                } else {
+                                    budsState.lastMatchedRule?.preset
+                                },
+                                onClick = {
+                                    onClose()
+                                    onEqualizerClick()
                                 },
                                 modifier = Modifier.animateItem().padding(horizontal = 16.dp, vertical = 8.dp)
                             )
@@ -490,7 +513,7 @@ fun AppSearchOverlay(
                         )
                     }
 
-                    val hasAnyResults = mNoiseControls || mOneEarbud || mAmbientCall || mInEarCall || mFitTest || mWearState || mSoundBalance || mFindBuds || mDoubleTap || mVoiceDetect || mPauseMedia || mActiveRule || mGlobalDefaults || matchingRules.isNotEmpty() || mGesturesStatus || mMovementCancelling || matchingGestures.isNotEmpty()
+                    val hasAnyResults = mNoiseControls || mOneEarbud || mAmbientCall || mInEarCall || mFitTest || mWearState || mSoundBalance || mFindBuds || mEqualizer || mDoubleTap || mVoiceDetect || mPauseMedia || mActiveRule || mGlobalDefaults || matchingRules.isNotEmpty() || mGesturesStatus || mMovementCancelling || matchingGestures.isNotEmpty()
 
                     if (!hasAnyResults) {
                         item(key = "empty_no_results") {

--- a/app/src/main/java/com/benegedeniz/budsdynamiceq/ui/buds/components/BudsScreenCards.kt
+++ b/app/src/main/java/com/benegedeniz/budsdynamiceq/ui/buds/components/BudsScreenCards.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.benegedeniz.budsdynamiceq.R
 import com.benegedeniz.budsdynamiceq.bluetooth.BudsModel
+import com.benegedeniz.budsdynamiceq.data.model.EqPreset
 import com.benegedeniz.budsdynamiceq.data.model.NoiseControlMode
 import com.benegedeniz.budsdynamiceq.data.model.PlacementState
 import com.benegedeniz.budsdynamiceq.ui.components.bounceClick
@@ -244,6 +245,59 @@ fun FitTestCard(
                         text = stringResource(R.string.requires_both_earbuds_to_be_worn),
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.error
+                    )
+                }
+            }
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(24.dp)
+            )
+        }
+    }
+}
+
+@Composable
+fun EqualizerCard(
+    isConnected: Boolean,
+    currentPreset: EqPreset?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .bounceClick(enabled = isConnected) { onClick() },
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp)
+                .alpha(if (isConnected) 1f else 0.5f),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Default.GraphicEq,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(24.dp)
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.equalizer),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                if (currentPreset != null && currentPreset != EqPreset.DEFAULT && currentPreset != EqPreset.IGNORE) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = stringResource(currentPreset.displayNameRes),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
             }

--- a/app/src/main/java/com/benegedeniz/budsdynamiceq/ui/equalizer/EqualizerScreen.kt
+++ b/app/src/main/java/com/benegedeniz/budsdynamiceq/ui/equalizer/EqualizerScreen.kt
@@ -1,0 +1,417 @@
+package com.benegedeniz.budsdynamiceq.ui.equalizer
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.drag
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.benegedeniz.budsdynamiceq.R
+import com.benegedeniz.budsdynamiceq.data.model.CustomEqualizer
+import com.benegedeniz.budsdynamiceq.data.model.EqPreset
+import com.benegedeniz.budsdynamiceq.data.model.EqRule
+import com.benegedeniz.budsdynamiceq.ui.components.PageHeader
+import com.benegedeniz.budsdynamiceq.ui.components.bounceClick
+import com.benegedeniz.budsdynamiceq.ui.components.rememberPageHeaderOverlayPadding
+import com.benegedeniz.budsdynamiceq.ui.rules.RulesViewModel
+import kotlinx.coroutines.delay
+
+@Composable
+fun EqualizerScreen(
+    viewModel: RulesViewModel,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    BackHandler { onBack() }
+    val uiState by viewModel.uiState.collectAsState()
+    val savedBands by viewModel.customEqBands.collectAsState()
+    val haptic = LocalHapticFeedback.current
+    val scrollState = rememberScrollState()
+    val headerOverlay = rememberPageHeaderOverlayPadding()
+
+    val supportsCustom = uiState.effectiveModel.supportsCustomEqualizer
+    val effectiveEq = remember(uiState.lastMatchedRule, uiState.manualPreset) {
+        effectiveEqPreset(uiState.lastMatchedRule, uiState.manualPreset)
+    }
+    val isCustomActive = effectiveEq == EqPreset.CUSTOM
+    val slidersEnabled = uiState.isConnected && supportsCustom && isCustomActive
+
+    var localBands by remember { mutableStateOf(savedBands) }
+    var isDragging by remember { mutableStateOf(false) }
+
+    LaunchedEffect(savedBands) {
+        if (!isDragging) localBands = savedBands
+    }
+
+    LaunchedEffect(localBands, slidersEnabled) {
+        if (!slidersEnabled) return@LaunchedEffect
+        delay(250)
+        viewModel.setCustomEqBands(localBands)
+    }
+
+    val displayedBands = if (isCustomActive) {
+        localBands
+    } else {
+        CustomEqualizer.previewBands(effectiveEq, savedBands)
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(scrollState)
+                .padding(
+                    start = 16.dp,
+                    end = 16.dp,
+                    top = headerOverlay.listTop,
+                    bottom = 32.dp
+                )
+        ) {
+            EqualizerChartCard(
+                bands = displayedBands,
+                enabled = slidersEnabled,
+                dimmed = !uiState.isConnected,
+                onBandChange = { index, value ->
+                    if (localBands.getOrNull(index) != value) {
+                        haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                    }
+                    localBands = localBands.toMutableList().also { it[index] = value }
+                },
+                onDragStateChange = { dragging -> isDragging = dragging }
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            val presetPairs = CustomEqualizer.WEARABLE_PRESETS.chunked(2)
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                presetPairs.forEach { pair ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        pair.forEach { preset ->
+                            EqPresetChip(
+                                preset = preset,
+                                selected = effectiveEq == preset,
+                                enabled = uiState.isConnected,
+                                modifier = Modifier.weight(1f),
+                                onClick = { viewModel.setManualPreset(preset) }
+                            )
+                        }
+                        if (pair.size == 1) {
+                            Spacer(modifier = Modifier.weight(1f))
+                        }
+                    }
+                }
+                if (supportsCustom) {
+                    EqPresetChip(
+                        preset = EqPreset.CUSTOM,
+                        selected = effectiveEq == EqPreset.CUSTOM,
+                        enabled = uiState.isConnected,
+                        modifier = Modifier.fillMaxWidth(0.5f),
+                        onClick = { viewModel.setManualPreset(EqPreset.CUSTOM) }
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = if (supportsCustom) {
+                    stringResource(R.string.equalizer_adjust_hint)
+                } else {
+                    stringResource(R.string.equalizer_custom_unsupported)
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = 8.dp)
+            )
+        }
+
+        PageHeader(
+            title = stringResource(R.string.equalizer),
+            isScrolled = scrollState.value > 10,
+            modifier = headerOverlay.headerModifier,
+            actionIcon = {
+                IconButton(
+                    onClick = {
+                        haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                        onBack()
+                    }
+                ) {
+                    Icon(Icons.Default.Close, contentDescription = stringResource(R.string.close))
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun EqPresetChip(
+    preset: EqPreset,
+    selected: Boolean,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    val background by animateColorAsState(
+        targetValue = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surface,
+        animationSpec = tween(180),
+        label = "eqChipBg"
+    )
+    val content by animateColorAsState(
+        targetValue = if (selected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface,
+        animationSpec = tween(180),
+        label = "eqChipFg"
+    )
+    Box(
+        modifier = modifier
+            .height(44.dp)
+            .clip(RoundedCornerShape(22.dp))
+            .background(background)
+            .alpha(if (enabled) 1f else 0.5f)
+            .bounceClick(enabled = enabled, onClick = onClick)
+            .padding(horizontal = 16.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = stringResource(preset.displayNameRes),
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium,
+            color = content,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun EqualizerChartCard(
+    bands: List<Int>,
+    enabled: Boolean,
+    dimmed: Boolean,
+    onBandChange: (Int, Int) -> Unit,
+    onDragStateChange: (Boolean) -> Unit
+) {
+    val curveColor = MaterialTheme.colorScheme.primary
+    val gridColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.28f)
+    val zeroLineColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.55f)
+    val labelColor = MaterialTheme.colorScheme.onSurfaceVariant
+    val gainColor = MaterialTheme.colorScheme.onSurface
+    val holeColor = MaterialTheme.colorScheme.surface
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(24.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = 12.dp, vertical = 16.dp)
+            .alpha(if (dimmed) 0.55f else 1f)
+    ) {
+        Row(modifier = Modifier.fillMaxWidth()) {
+            bands.forEachIndexed { index, gain ->
+                Text(
+                    text = CustomEqualizer.formatGain(gain),
+                    modifier = Modifier.weight(1f),
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = gainColor,
+                    fontSize = 12.sp
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(220.dp)
+        ) {
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                val bandWidth = size.width / bands.size
+                val steps = 4
+                for (i in 0..steps) {
+                    val y = size.height * i / steps
+                    drawLine(
+                        color = if (i == steps / 2) zeroLineColor else gridColor,
+                        start = Offset(0f, y),
+                        end = Offset(size.width, y),
+                        strokeWidth = if (i == steps / 2) 1.5.dp.toPx() else 1.dp.toPx()
+                    )
+                }
+                for (i in 0..bands.size) {
+                    val x = bandWidth * i
+                    drawLine(
+                        color = gridColor,
+                        start = Offset(x, 0f),
+                        end = Offset(x, size.height),
+                        strokeWidth = 1.dp.toPx()
+                    )
+                }
+
+                val points = bands.mapIndexed { index, gain ->
+                    Offset(
+                        x = bandWidth * (index + 0.5f),
+                        y = gainToY(gain, size.height)
+                    )
+                }
+                if (points.size >= 2) {
+                    val curve = smoothPath(points)
+                    val fill = Path().apply {
+                        addPath(curve)
+                        lineTo(points.last().x, size.height)
+                        lineTo(points.first().x, size.height)
+                        close()
+                    }
+                    drawPath(
+                        path = fill,
+                        brush = Brush.verticalGradient(
+                            colors = listOf(curveColor.copy(alpha = 0.28f), Color.Transparent)
+                        )
+                    )
+                    drawPath(
+                        path = curve,
+                        color = curveColor,
+                        style = Stroke(width = 2.5.dp.toPx(), cap = StrokeCap.Round)
+                    )
+                    points.forEach { point ->
+                        drawCircle(color = curveColor, radius = 6.dp.toPx(), center = point)
+                        drawCircle(color = holeColor, radius = 2.5.dp.toPx(), center = point)
+                    }
+                }
+            }
+            Row(modifier = Modifier.fillMaxSize()) {
+                bands.forEachIndexed { index, _ ->
+                    val label = CustomEqualizer.BAND_LABELS[index]
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxHeight()
+                            .semantics {
+                                contentDescription = label
+                            }
+                            .pointerInput(enabled, index) {
+                                if (!enabled) return@pointerInput
+                                awaitEachGesture {
+                                    val down = awaitFirstDown()
+                                    onDragStateChange(true)
+                                    onBandChange(index, yToGain(down.position.y, size.height.toFloat()))
+                                    drag(down.id) { change ->
+                                        change.consume()
+                                        onBandChange(index, yToGain(change.position.y, size.height.toFloat()))
+                                    }
+                                    onDragStateChange(false)
+                                }
+                            }
+                    )
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(modifier = Modifier.fillMaxWidth()) {
+            CustomEqualizer.BAND_LABELS.forEach { label ->
+                Text(
+                    text = label,
+                    modifier = Modifier.weight(1f),
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = labelColor,
+                    maxLines = 1
+                )
+            }
+        }
+    }
+}
+
+private fun gainToY(gain: Int, height: Float): Float {
+    val range = (CustomEqualizer.GAIN_MAX - CustomEqualizer.GAIN_MIN).toFloat()
+    return height * (CustomEqualizer.GAIN_MAX - gain) / range
+}
+
+private fun yToGain(y: Float, height: Float): Int {
+    if (height <= 0f) return 0
+    val t = (y / height).coerceIn(0f, 1f)
+    val gain = CustomEqualizer.GAIN_MAX - t * (CustomEqualizer.GAIN_MAX - CustomEqualizer.GAIN_MIN)
+    return gain.kotlinRoundToInt()
+}
+
+private fun Float.kotlinRoundToInt(): Int = kotlin.math.round(this).toInt().coerceIn(
+    CustomEqualizer.GAIN_MIN,
+    CustomEqualizer.GAIN_MAX
+)
+
+private fun smoothPath(points: List<Offset>): Path {
+    val path = Path()
+    if (points.isEmpty()) return path
+    path.moveTo(points[0].x, points[0].y)
+    if (points.size == 1) return path
+    for (i in 0 until points.lastIndex) {
+        val p0 = points[i]
+        val p1 = points[i + 1]
+        val c1 = Offset(p0.x + (p1.x - p0.x) / 2f, p0.y)
+        val c2 = Offset(p0.x + (p1.x - p0.x) / 2f, p1.y)
+        path.cubicTo(c1.x, c1.y, c2.x, c2.y, p1.x, p1.y)
+    }
+    return path
+}
+
+private fun effectiveEqPreset(lastMatchedRule: EqRule?, manualPreset: EqPreset?): EqPreset {
+    val rulePreset = lastMatchedRule?.preset
+    return when {
+        rulePreset == null || rulePreset == EqPreset.DEFAULT -> manualPreset ?: EqPreset.NORMAL
+        else -> rulePreset
+    }
+}

--- a/app/src/main/java/com/benegedeniz/budsdynamiceq/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/benegedeniz/budsdynamiceq/ui/main/MainScreen.kt
@@ -53,7 +53,7 @@ import com.benegedeniz.budsdynamiceq.ui.wearstate.WearStateViewModel
 import kotlinx.coroutines.launch
 
 // Sub-screen enum for flag-based navigation (no NavHost lifecycle transitions)
-private enum class SubScreen { NONE, FIT_TEST, WEAR_STATE, SOUND_BALANCE, SETTINGS, FIND_MY_BUDS }
+private enum class SubScreen { NONE, FIT_TEST, WEAR_STATE, SOUND_BALANCE, SETTINGS, FIND_MY_BUDS, EQUALIZER }
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -168,6 +168,7 @@ fun MainScreen() {
                         onSoundBalanceTestClick = { activeSubScreen = SubScreen.SOUND_BALANCE },
                         onSettingsClick = { activeSubScreen = SubScreen.SETTINGS },
                         onFindMyBudsClick = { activeSubScreen = SubScreen.FIND_MY_BUDS },
+                        onEqualizerClick = { activeSubScreen = SubScreen.EQUALIZER },
                         onOpenSearch = { isAppSearchVisible = true },
                         modifier = Modifier.fillMaxSize()
                     )
@@ -263,6 +264,11 @@ fun MainScreen() {
                             onBack = { activeSubScreen = SubScreen.NONE },
                             modifier = Modifier.fillMaxSize()
                         )
+                        SubScreen.EQUALIZER -> com.benegedeniz.budsdynamiceq.ui.equalizer.EqualizerScreen(
+                            viewModel = rulesViewModel,
+                            onBack = { activeSubScreen = SubScreen.NONE },
+                            modifier = Modifier.fillMaxSize()
+                        )
                         SubScreen.NONE -> {}
                     }
                 }
@@ -282,7 +288,8 @@ fun MainScreen() {
             onFitTestClick = { activeSubScreen = SubScreen.FIT_TEST },
             onWearStateClick = { activeSubScreen = SubScreen.WEAR_STATE },
             onSoundBalanceTestClick = { activeSubScreen = SubScreen.SOUND_BALANCE },
-            onFindMyBudsClick = { activeSubScreen = SubScreen.FIND_MY_BUDS }
+            onFindMyBudsClick = { activeSubScreen = SubScreen.FIND_MY_BUDS },
+            onEqualizerClick = { activeSubScreen = SubScreen.EQUALIZER }
         )
 
         // ── Dialogs ────────────────────────────────────────────────────────

--- a/app/src/main/java/com/benegedeniz/budsdynamiceq/ui/rules/RulesScreen.kt
+++ b/app/src/main/java/com/benegedeniz/budsdynamiceq/ui/rules/RulesScreen.kt
@@ -521,6 +521,9 @@ fun RuleEditScreen(
     var artistSelected by remember { mutableStateOf(false) }
     var genreSelected by remember { mutableStateOf(false) }
 
+    val budsController = com.benegedeniz.budsdynamiceq.di.ServiceLocator.provideBudsController(LocalContext.current)
+    val effectiveModel = budsController.effectiveModel.collectAsState().value
+
     val isBadgeSelected = titleSelected || artistSelected || genreSelected
 
     val isMatch = remember(keyword, currentMetadata) {
@@ -824,7 +827,9 @@ fun RuleEditScreen(
                             onDismissRequest = { expanded = false },
                             modifier = Modifier.background(MaterialTheme.colorScheme.surface)
                         ) {
-                            EqPreset.entries.forEach { preset ->
+                            EqPreset.entries.filter {
+                                it != EqPreset.CUSTOM || effectiveModel.supportsCustomEqualizer
+                            }.forEach { preset ->
                                 DropdownMenuItem(
                                     text = { Text(stringResource(preset.displayNameRes)) },
                                     onClick = {
@@ -857,8 +862,6 @@ fun RuleEditScreen(
                             onDismissRequest = { ncExpanded = false },
                             modifier = Modifier.background(MaterialTheme.colorScheme.surface)
                         ) {
-                            val budsController = com.benegedeniz.budsdynamiceq.di.ServiceLocator.provideBudsController(androidx.compose.ui.platform.LocalContext.current)
-                            val effectiveModel = budsController.effectiveModel.collectAsState().value
                             NoiseControlMode.entries.filter { (it != NoiseControlMode.ADAPTIVE || effectiveModel.supportsAdaptiveNC) && (it != NoiseControlMode.TRANSPARENT || effectiveModel.supportsTransparencyNC) }.forEach { ncMode ->
                                 DropdownMenuItem(
                                     text = { Text(stringResource(ncMode.displayNameRes)) },

--- a/app/src/main/java/com/benegedeniz/budsdynamiceq/ui/rules/RulesViewModel.kt
+++ b/app/src/main/java/com/benegedeniz/budsdynamiceq/ui/rules/RulesViewModel.kt
@@ -34,6 +34,8 @@ class RulesViewModel(application: Application) : AndroidViewModel(application) {
     var isEditScreenOpen by androidx.compose.runtime.mutableStateOf(false)
     var editingRule by androidx.compose.runtime.mutableStateOf<EqRule?>(null)
 
+    val customEqBands = budsController.customEqBands
+
     val uiState: StateFlow<RulesUiState> = combine(
         combine(
             repository.rules,
@@ -179,6 +181,10 @@ class RulesViewModel(application: Application) : AndroidViewModel(application) {
         if (budsController.lastMatchedRule.value == null) {
             budsController.sendEqualizer(preset)
         }
+    }
+
+    fun setCustomEqBands(bands: List<Int>) {
+        budsController.setCustomEqBands(bands)
     }
 
     fun setManualNoiseControl(ncMode: NoiseControlMode) {

--- a/app/src/main/java/com/benegedeniz/budsdynamiceq/ui/rules/components/RulesScreenCards.kt
+++ b/app/src/main/java/com/benegedeniz/budsdynamiceq/ui/rules/components/RulesScreenCards.kt
@@ -117,7 +117,9 @@ fun GlobalDefaultsCard(
                             onDismissRequest = { expanded = false },
                             modifier = Modifier.background(MaterialTheme.colorScheme.surface, RoundedCornerShape(16.dp))
                         ) {
-                            EqPreset.entries.filter { it != EqPreset.DEFAULT }.forEach { preset ->
+                            EqPreset.entries.filter {
+                                it != EqPreset.DEFAULT && (it != EqPreset.CUSTOM || effectiveModel.supportsCustomEqualizer)
+                            }.forEach { preset ->
                                 DropdownMenuItem(
                                     text = { Text(stringResource(preset.displayNameRes)) },
                                     onClick = {

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -290,6 +290,9 @@
 	<string name="eq_dynamic">Dinamik</string>
 	<string name="eq_clear">Aydın</string>
 	<string name="eq_treble_boost">Tiz artırma</string>
+	<string name="eq_custom">Fərdi</string>
+	<string name="equalizer_adjust_hint">Səsi zövqünüzə görə tənzimləyin.</string>
+	<string name="equalizer_custom_unsupported">Zolaq üzrə tənzimləmə Galaxy Buds 3 və yenilərində mövcuddur.</string>
 	<string name="nc_default">Standart</string>
 	<string name="nc_ignore">Dəyişmə</string>
 	<string name="nc_off">Söndürülmüş</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -291,6 +291,9 @@
 	<string name="eq_dynamic">Динамичный</string>
 	<string name="eq_clear">Чистый</string>
 	<string name="eq_treble_boost">Усиление высоких</string>
+	<string name="eq_custom">Пользовательский</string>
+	<string name="equalizer_adjust_hint">Настройте звук под себя.</string>
+	<string name="equalizer_custom_unsupported">Полосная настройка доступна на Galaxy Buds 3 и новее.</string>
 	<string name="nc_default">По умолчанию</string>
 	<string name="nc_ignore">Не менять</string>
 	<string name="nc_off">Выкл.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -290,6 +290,9 @@
 	<string name="eq_dynamic">Dinamik</string>
 	<string name="eq_clear">Net</string>
 	<string name="eq_treble_boost">Tiz artırma</string>
+	<string name="eq_custom">Özel</string>
+	<string name="equalizer_adjust_hint">Sesi zevkinize göre ayarlayın.</string>
+	<string name="equalizer_custom_unsupported">Bant bazlı ayar Galaxy Buds 3 ve sonraki modellerde kullanılabilir.</string>
 	<string name="nc_default">Varsayılan</string>
 	<string name="nc_ignore">Değiştirme</string>
 	<string name="nc_off">Kapalı</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -291,6 +291,9 @@
 	<string name="eq_dynamic">Dynamic</string>
 	<string name="eq_clear">Clear</string>
 	<string name="eq_treble_boost">Treble boost</string>
+	<string name="eq_custom">Custom</string>
+	<string name="equalizer_adjust_hint">Adjust the sound to your taste.</string>
+	<string name="equalizer_custom_unsupported">Per-band tuning is available on Galaxy Buds 3 and newer.</string>
 	<string name="nc_default">Default</string>
 	<string name="nc_ignore">Don\'t Change</string>
 	<string name="nc_off">Off</string>

--- a/app/src/test/java/com/benegedeniz/budsdynamiceq/bluetooth/SppPacketEncoderTest.kt
+++ b/app/src/test/java/com/benegedeniz/budsdynamiceq/bluetooth/SppPacketEncoderTest.kt
@@ -28,4 +28,17 @@ class SppPacketEncoderTest {
         assertEquals(0x03.toByte(), packet[4])
 
     }
+
+    @Test
+    fun buildCustomEqualizerPayload_bandCountThenSignedGains() {
+        val payload = SppPacketEncoder.buildCustomEqualizerPayload(listOf(6, 3, 0, 0, 1, 1, 3, 5, -4))
+        assertEquals(10, payload.size)
+        assertEquals(9.toByte(), payload[0])
+        assertEquals(6.toByte(), payload[1])
+        assertEquals((-4).toByte(), payload[9])
+
+        val packet = SppPacketEncoder.buildPacket(SppPacketEncoder.MSG_ID_CUSTOM_EQUALIZE_SEND, payload)
+        assertEquals(0x89.toByte(), packet[3])
+        assertEquals(9.toByte(), packet[4])
+    }
 }

--- a/app/src/test/java/com/benegedeniz/budsdynamiceq/data/model/CustomEqualizerTest.kt
+++ b/app/src/test/java/com/benegedeniz/budsdynamiceq/data/model/CustomEqualizerTest.kt
@@ -1,0 +1,42 @@
+package com.benegedeniz.budsdynamiceq.data.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CustomEqualizerTest {
+
+    @Test
+    fun clamp_outOfRangeAndWrongSize() {
+        assertEquals(CustomEqualizer.FLAT, CustomEqualizer.clamp(listOf(1, 2)))
+        assertEquals(
+            listOf(-10, 10, 0, 0, 0, 0, 0, 0, 0),
+            CustomEqualizer.clamp(listOf(-99, 99, 0, 0, 0, 0, 0, 0, 0))
+        )
+    }
+
+    @Test
+    fun serializeAndParse_roundTrip() {
+        val bands = listOf(6, 3, 0, 0, 1, 1, 3, 5, 5)
+        val stored = CustomEqualizer.serialize(bands)
+        assertEquals("6,3,0,0,1,1,3,5,5", stored)
+        assertEquals(bands, CustomEqualizer.parseStored(stored))
+    }
+
+    @Test
+    fun parseStored_invalidFallsBackToFlat() {
+        assertEquals(CustomEqualizer.FLAT, CustomEqualizer.parseStored(null))
+        assertEquals(CustomEqualizer.FLAT, CustomEqualizer.parseStored("1,2,nope"))
+    }
+
+    @Test
+    fun formatGain_signed() {
+        assertEquals("+6", CustomEqualizer.formatGain(6))
+        assertEquals("0", CustomEqualizer.formatGain(0))
+        assertEquals("-3", CustomEqualizer.formatGain(-3))
+    }
+
+    @Test
+    fun customPreset_usesWearablePayload() {
+        assertEquals(0x07.toByte(), EqPreset.CUSTOM.payloadByte)
+    }
+}


### PR DESCRIPTION
Galaxy Wearable already has a 9-band custom equalizer, and I really missed that in Bud Buddy — being able to tune the sound yourself instead of only picking a preset. I added it here.

## Summary
- New Equalizer screen on the home tab (presets + **Custom**)
- 9 bands (63 Hz–16 kHz), same layout as Galaxy Wearable
- Custom can also be chosen in Music Rules
- Aimed at Galaxy Buds 3 / 3 Pro / 4 / 4 Pro

![Custom equalizer](https://github.com/MrMe0ws/BudBuddy/releases/download/v1.6.0/equalizer-preview.png)

## Test plan
- [x] Connect Buds 4 Pro (or Buds 3 / 4)
- [x] Open **Equalizer** from the home tab
- [x] Select **Custom**, drag the bands, confirm the sound changes
- [x] Switch noise control and confirm the custom curve stays applied
- [x] Select **Custom** in a Music Rule
